### PR TITLE
update production configuration to resolve ssl rejection; add pg-native

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -23,9 +23,9 @@ module.exports = {
   //   dialect: "postgres"
   // },
   production: {
-    use_env_variable: "DATABASE_URL",
+    url: process.env.DATABASE_URL,
     dialect: "postgres",
-    dialectoptions: {
+    dialectOptions: {
       ssl: {
         require: true,
         rejectUnauthorized: false

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -7,10 +7,11 @@ let sequelize;
 if (env === 'production') {
   console.log("PROD")
   sequelize = new Sequelize(
-    process.env[config.use_env_variable],
+    config.url,
     {
       dialect: 'postgres',
-      dialectOptions: config.dialectoptions,
+      dialectOptions: config.dialectOptions,
+      native: true,
     }
   );
 } else {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,7 @@
                 "node-cache": "^5.1.2",
                 "openai": "^4.87.3",
                 "pg": "^8.13.3",
+                "pg-native": "^3.5.0",
                 "sequelize": "^6.37.6",
                 "sequelize-cli": "^6.6.2"
             },
@@ -615,6 +616,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
             }
         },
         "node_modules/bluebird": {
@@ -1405,6 +1414,11 @@
                 "type": "^2.7.2"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1892,6 +1906,16 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/libpq": {
+            "version": "1.8.15",
+            "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.15.tgz",
+            "integrity": "sha512-4lSWmly2Nsj3LaTxxtFmJWuP3Kx+0hYHEd+aNrcXEWT0nKWaPd9/QZPiMkkC680zeALFGHQdQWjBvnilL+vgWA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "bindings": "1.5.0",
+                "nan": "~2.22.2"
+            }
+        },
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2044,6 +2068,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/nan": {
+            "version": "2.22.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+            "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ=="
         },
         "node_modules/negotiator": {
             "version": "0.6.3",
@@ -2341,6 +2370,15 @@
             "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
             "engines": {
                 "node": ">=4.0.0"
+            }
+        },
+        "node_modules/pg-native": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/pg-native/-/pg-native-3.5.0.tgz",
+            "integrity": "sha512-rj4LYouevTdKxvRLnvtOLEPOerkiPAqUdZE1K48IfQluEH/x7GrldEDdSaEOmJ6z7s6LQwDTpAPhm2s00iG8xw==",
+            "dependencies": {
+                "libpq": "^1.8.15",
+                "pg-types": "2.2.0"
             }
         },
         "node_modules/pg-pool": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
         "node-cache": "^5.1.2",
         "openai": "^4.87.3",
         "pg": "^8.13.3",
+        "pg-native": "^3.5.0",
         "sequelize": "^6.37.6",
         "sequelize-cli": "^6.6.2"
     },


### PR DESCRIPTION
Fix: resolve Heroku Postgres SSL connection issues with Sequelize

- Added `url` key in production config to hold full DB connection string with `?sslmode=require`
- Corrected `dialectOptions` casing in config.js to ensure SSL options are recognized
- Added `pg-native` dependency and enabled native bindings for improved SSL handling
- Configured SSL options with `require: true` and `rejectUnauthorized: false` to bypass self-signed certificate errors on Heroku
- Ensured consistent use of config.js by Sequelize CLI and app runtime for migrations and production
- Changes fixed `pg_hba.conf` SSL off errors and certificate verification failures, enabling successful Sequelize migrations and DB connections in production test environment
